### PR TITLE
Fix DeltaColumn nullability handling

### DIFF
--- a/src/models/column.py
+++ b/src/models/column.py
@@ -16,4 +16,8 @@ class DeltaColumn:
     @property
     def struct_field(self) -> T.StructField:
         """PySpark `StructField` representation of a column."""
-        return T.StructField(self.name, self.data_type, False)
+        # Ensure the StructField accurately reflects the column's nullability.
+        # Previously this always set ``nullable`` to ``False`` which meant
+        # nullable columns were incorrectly represented as non-nullable in the
+        # resulting schema.
+        return T.StructField(self.name, self.data_type, self.is_nullable)

--- a/tests/models/test_column.py
+++ b/tests/models/test_column.py
@@ -4,8 +4,14 @@ from src.models.column import DeltaColumn
 
 
 class TestStructField:
-    def test_struct_fielf(self):
+    def test_struct_field_non_nullable(self):
         input_column = DeltaColumn(name="foo", data_type=T.StringType(), is_nullable=False)
         expected = T.StructField(name="foo", dataType=T.StringType(), nullable=False)
+        actual = input_column.struct_field
+        assert expected == actual
+
+    def test_struct_field_nullable(self):
+        input_column = DeltaColumn(name="foo", data_type=T.StringType(), is_nullable=True)
+        expected = T.StructField(name="foo", dataType=T.StringType(), nullable=True)
         actual = input_column.struct_field
         assert expected == actual


### PR DESCRIPTION
## Summary
- respect `DeltaColumn.is_nullable` when building `StructField`
- add tests for nullable and non-nullable columns

## Testing
- `python -m py_compile src/models/column.py tests/models/test_column.py`
- `pytest tests/models/test_column.py::TestStructField::test_struct_field_nullable -q` *(fails: ModuleNotFoundError: No module named 'pyspark')*


------
https://chatgpt.com/codex/tasks/task_e_688e2b47e7448330827955d6b38c6fff