### PR TITLE
Add ForeignKey metadata and apply to silver tables

### DIFF
--- a/src/models/column.py
+++ b/src/models/column.py
@@ -4,6 +4,14 @@ import pyspark.sql.types as T
 
 
 @dataclass(frozen=True)
+class ForeignKey:
+    """Represents a foreign key constraint."""
+
+    table_name: str
+    column_name: str
+
+
+@dataclass(frozen=True)
 class DeltaColumn:
     """Represents a Delta Table column."""
 
@@ -12,6 +20,7 @@ class DeltaColumn:
     comment: str = ""
     is_primary_key: bool = False
     is_nullable: bool = True
+    foreign_key: ForeignKey | None = None
 
     @property
     def struct_field(self) -> T.StructField:

--- a/src/silver/orders.py
+++ b/src/silver/orders.py
@@ -9,7 +9,7 @@ from pyspark.sql import SparkSession
 
 from src import settings
 from src.enums import Medallion
-from src.models.column import DeltaColumn
+from src.models.column import DeltaColumn, ForeignKey
 from src.models.table import DeltaTable
 
 orders = DeltaTable(
@@ -29,6 +29,7 @@ orders = DeltaTable(
             data_type=T.IntegerType(),
             is_nullable=False,
             comment="Identifier for the user who placed the order",
+            foreign_key=ForeignKey(table_name="users", column_name="user_id"),
         ),
         DeltaColumn(
             name="evaluation_set",

--- a/src/silver/products.py
+++ b/src/silver/products.py
@@ -9,7 +9,7 @@ from pyspark.sql import SparkSession
 
 from src import settings
 from src.enums import Medallion
-from src.models.column import DeltaColumn
+from src.models.column import DeltaColumn, ForeignKey
 from src.models.table import DeltaTable
 
 products = DeltaTable(
@@ -35,12 +35,14 @@ products = DeltaTable(
             data_type=T.IntegerType(),
             is_nullable=False,
             comment="Identifier of the aisle containing the product",
+            foreign_key=ForeignKey(table_name="aisles", column_name="aisle_id"),
         ),
         DeltaColumn(
             name="department_id",
             data_type=T.IntegerType(),
             is_nullable=False,
             comment="Identifier of the department for the product",
+            foreign_key=ForeignKey(table_name="departments", column_name="department_id"),
         ),
     ],
 )

--- a/tests/models/test_column.py
+++ b/tests/models/test_column.py
@@ -1,6 +1,6 @@
 from pyspark.sql import types as T
 
-from src.models.column import DeltaColumn
+from src.models.column import DeltaColumn, ForeignKey
 
 
 class TestStructField:
@@ -9,6 +9,11 @@ class TestStructField:
         expected = T.StructField(name="foo", dataType=T.StringType(), nullable=False)
         actual = input_column.struct_field
         assert expected == actual
+
+    def test_foreign_key(self):
+        fk = ForeignKey(table_name="bar", column_name="id")
+        column = DeltaColumn(name="foo_id", data_type=T.IntegerType(), foreign_key=fk)
+        assert column.foreign_key == fk
 
     def test_struct_field_nullable(self):
         input_column = DeltaColumn(name="foo", data_type=T.StringType(), is_nullable=True)


### PR DESCRIPTION
## Summary
- introduce `ForeignKey` dataclass to describe foreign key relationships
- extend `DeltaColumn` with optional `foreign_key` metadata
- link silver `orders` and `products` columns to their referenced tables
- add tests for `ForeignKey` behavior

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyspark')*
- `bash lint.sh` *(fails: Missing imports for pyspark, delta-spark, etc. during mypy check)*

------
https://chatgpt.com/codex/tasks/task_e_688e48d2a78c833099e37cf5d734b96b