### PR TITLE
Add descriptive comments to DeltaTable definitions

### DIFF
--- a/src/gold/order_fact.py
+++ b/src/gold/order_fact.py
@@ -16,6 +16,7 @@ order_fact = DeltaTable(
     table_name="order_fact",
     schema_name=Medallion.GOLD,
     catalog_name=settings.CATALOG,
+    comment="Fact table capturing core metrics for each order",
     columns=[
         DeltaColumn(
             name="order_id",

--- a/src/gold/product_dimension.py
+++ b/src/gold/product_dimension.py
@@ -19,6 +19,7 @@ product_dimension = DeltaTable(
     table_name="product_dimension",
     schema_name=Medallion.GOLD,
     catalog_name=settings.CATALOG,
+    comment="Dimension table combining product, aisle, and department details",
     columns=[
         DeltaColumn(
             name="product_id",

--- a/src/metadata/data_quality/data_quality_checks.py
+++ b/src/metadata/data_quality/data_quality_checks.py
@@ -15,6 +15,7 @@ data_quality_checks: DeltaTable = DeltaTable(
     table_name=DATA_QUALITY_TABLE_NAME,
     schema_name=Medallion.METADATA,
     catalog_name=settings.CATALOG,
+    comment="Audit log of data quality check results",
     columns=[
         DeltaColumn(name="date", data_type=T.DateType(), is_nullable=False),
         DeltaColumn(name="severity", data_type=T.StringType(), is_nullable=False),

--- a/src/silver/aisle.py
+++ b/src/silver/aisle.py
@@ -16,6 +16,7 @@ aisle = DeltaTable(
     table_name="aisle",
     schema_name=Medallion.SILVER,
     catalog_name=settings.CATALOG,
+    comment="Reference data for aisles",
     columns=[
         DeltaColumn(
             name="aisle_id",

--- a/src/silver/department.py
+++ b/src/silver/department.py
@@ -16,6 +16,7 @@ department = DeltaTable(
     table_name="department",
     schema_name=Medallion.SILVER,
     catalog_name=settings.CATALOG,
+    comment="Reference data for departments",
     columns=[
         DeltaColumn(
             name="department_id",

--- a/src/silver/order.py
+++ b/src/silver/order.py
@@ -16,6 +16,7 @@ order = DeltaTable(
     table_name="order",
     schema_name=Medallion.SILVER,
     catalog_name=settings.CATALOG,
+    comment="Cleaned order data capturing user and timing details",
     columns=[
         DeltaColumn(
             name="order_id",

--- a/src/silver/product.py
+++ b/src/silver/product.py
@@ -19,6 +19,7 @@ product = DeltaTable(
     table_name="product",
     schema_name=Medallion.SILVER,
     catalog_name=settings.CATALOG,
+    comment="Reference data for products with aisle and department identifiers",
     columns=[
         DeltaColumn(
             name="product_id",

--- a/tests/models/test_table.py
+++ b/tests/models/test_table.py
@@ -18,6 +18,7 @@ def delta_table(example_columns):
         table_name="my_table",
         schema_name="public",
         catalog_name="main",
+        comment="Table used for unit tests",
         columns=example_columns,
     )
 


### PR DESCRIPTION
## Summary
- add missing comments for silver Delta tables (product, order, department, aisle)
- document gold tables with clear comments (order_fact, product_dimension)
- annotate metadata and test Delta tables with comments

## Testing
- `bash lint.sh` *(fails: Cannot find implementation or library stub for module named 'pyspark')*
- `pip install pyspark` *(fails: Could not find a version that satisfies the requirement pyspark)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyspark')*

------
https://chatgpt.com/codex/tasks/task_e_688f91305fdc8330a1a60736390266ff